### PR TITLE
fix: adjust client-side callsign regex to handle 2x1 callsigns

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
     setZipcodeFound("");
 
     // Callsign input validation
-    const callSignRegex = /^(?:[KNWM]|A[A-L]|[KNW][A-Z])[0-9][A-Z]{2,3}$/;
+    const callSignRegex = /^(?:[KNWM]|A[A-L]|[KNW][A-Z])[0-9][A-Z]{1,3}$/;
     if (!callSignRegex.test(callSign)) {
       setCallSignError("Invalid FCC Call Sign");
       return;


### PR DESCRIPTION
Follow-up to #251, which fixed the server-side callsign regex in `src/create_pass.ts` but left the identical pattern in `app/page.tsx:61` at `{2,3}`.

That client-side check runs first in `handleSubmit` and returns early with "Invalid FCC Call Sign", so the form still rejected 2x1 callsigns like `AK8N` before any request could reach the Lambda. Without this, #250 isn't actually fixed from the user's perspective.

## Verification

Both regexes now read `{1,3}` and are in sync. Checked the new pattern against real callsigns:

| Callsign | Before | After | Notes |
|---|---|---|---|
| `AK8N` | ✗ | ✓ | The 2x1 vanity call from #250 |
| `AA1A`, `KA1B` | ✗ | ✓ | Other 2x1 vanity calls |
| `W1AW`, `KE4ABC` | ✓ | ✓ | Unaffected |
| `AM1A`, `K1`, `KE4ABCD` | ✗ | ✗ | Still correctly rejected |

`npm run build` passes.

## Notes

- This also newly accepts 1x1 special-event calls (`K1A`, `W5X`) on the client, matching the server behavior #251 introduced. Intentional and consistent across both layers.
- The regex is still duplicated across `app/page.tsx` and `src/create_pass.ts` — this drift is what caused the incomplete fix. Not deduplicating here: `app/` doesn't import from `src/` anywhere, and those are SST Lambda handlers that pull in the AWS SDK, so sharing would need a new neutral module. Worth a separate PR.

Completes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)