### PR TITLE
fix: bump cloudflare provider pin to satisfy sst 4.17.1

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -8,7 +8,7 @@ export default $config({
       home: "aws",
       providers: {
         aws: { region: "us-east-1" },
-        cloudflare: "6.13.0",
+        cloudflare: "6.17.0",
       },
     };
   },


### PR DESCRIPTION
Unblocks the production deploy, which has been failing on `main`.

## The failure

```
✕  You specified version 6.13.0 of the "cloudflare" provider. SST needs 6.15.0 or higher.
```

The deploy dies during `sst refresh`, before it reaches any application code.

## Root cause

Dependency drift, with no edit to either side:

- `package.json` floats SST at `^4.17.0`
- `package-lock.json` pins `4.17.0`
- the deploy workflow runs `npm i --legacy-peer-deps`, **not** `npm ci` — so the lockfile isn't respected and CI resolves **4.17.1**
- SST 4.17.1 raised its minimum cloudflare provider to **6.15.0**, while `sst.config.ts` still pinned **6.13.0**

## The fix

Pinned to `6.17.0` — the latest stable `@pulumi/cloudflare` — rather than the bare `6.15.0` floor, so the next SST patch bump doesn't immediately re-break the deploy. Minor bump within the same major, so it shouldn't force replacement of the DNS resources.

Verified against the SST 4.17.1 binary, which carries the error template `You specified version %s of the "%s" provider. SST needs %s or higher.` alongside the literal `6.15.0` as its floor. `6.17.0` satisfies it.

## Why this matters now

#251 and #252 fix the 2x1 callsign regex (#250), but **neither reaches production** while the deploy is broken. This is the delivery path for both.

## Follow-ups (not in this PR)

- **`npm i` → `npm ci`** in `.github/workflows/sst-deploy.yml` is the actual durable fix for the drift — it would make deploys reproducible instead of silently resolving new versions. Left out here because changing CI install semantics deserves its own review.
- Deploys have been red since March (last green was a manual dispatch on 2026-05-06), so this `refresh`/`deploy` runs against ~2 months of accumulated drift and may surface more than just the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)